### PR TITLE
Make the AMASS z_up a Node rotation to fix the joint orientation bug.

### DIFF
--- a/aitviewer/renderables/point_clouds.py
+++ b/aitviewer/renderables/point_clouds.py
@@ -27,7 +27,7 @@ class PointClouds(Node):
     Draw a point clouds man!
     """
 
-    def __init__(self, points, colors=None, point_size=5.0, color=(0.0, 0.0, 1.0, 1.0), **kwargs):
+    def __init__(self, points, colors=None, point_size=5.0, color=(0.0, 0.0, 1.0, 1.0), z_up=False, **kwargs):
         """
         A sequence of point clouds. Each point cloud can have a varying number of points.
         :param points: Sequence of points (F, P, 3)
@@ -47,6 +47,9 @@ class PointClouds(Node):
         self.max_n_points = max([p.shape[0] for p in self.points])
 
         self.vao = VAO("points", mode=moderngl.POINTS)
+        
+        if z_up:
+            self.rotation =  np.matmul(np.array([[1, 0, 0], [0, 0, 1], [0, -1, 0]]), self.rotation)
 
     @property
     def points(self):

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -146,6 +146,9 @@ class SMPLSequence(Node):
             global_oris = c2c(global_oris.reshape((self.n_frames, -1, 3, 3)))
         else:
             global_oris = np.tile(np.eye(3), self.joints.shape[:-1])[np.newaxis]
+            
+        if self._z_up:
+            self.rotation = np.matmul(np.array([[1, 0, 0], [0, 0, 1], [0, -1, 0]]), self.rotation) 
 
         self.rbs = RigidBodies(self.joints, global_oris, length=0.1, name='Joint Angles')
         self.rbs.position = self.position
@@ -307,13 +310,7 @@ class SMPLSequence(Node):
                                         betas=betas,
                                         trans=trans)
 
-        # Transform output vertices and joints into our viewer's coordinate system (where Y is up).
-        # We do this on the joints and not on the root pose of SMPL because the SMPL root does not correspond
-        # to the SMPL origin as pointed out by: https://github.com/eth-ait/aitviewer/issues/5
-        if self._z_up:
-            to_y_up = torch.Tensor([[1, 0, 0], [0, 0, 1], [0, -1, 0]]).to(verts.device, dtype=verts.dtype)
-            verts = torch.matmul(to_y_up.unsqueeze(0), verts.unsqueeze(-1)).squeeze(-1)
-            joints = torch.matmul(to_y_up.unsqueeze(0), joints.unsqueeze(-1)).squeeze(-1)
+
 
         skeleton = self.smpl_layer.skeletons()['body'].T
         faces = self.smpl_layer.bm.faces.astype(np.int64)

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -38,7 +38,8 @@ if __name__ == '__main__':
     # illumination model on the point clouds).
     #
     # Move the point cloud a bit along the x-axis so it doesn't overlap with the mesh data.
-    ptc_amass = PointClouds(seq_amass.vertices, position=np.array([1.0, 0.0, 0.0]), color=c)
+    # Amass data need to be rotated to get the z axis up.
+    ptc_amass = PointClouds(seq_amass.vertices, position=np.array([1.0, 0.0, 0.0]), color=c, z_up=True)
 
     # Display in the viewer.
     v = Viewer()


### PR DESCRIPTION
In AMASS, the SMPL mesh needs to be rotated to be displayed head up in the viewer. This was discussed in  #issue-1321548505.

I found that the way it is done introduces wrong joint orientations for AMASS. 

Here is the joints orientation of SMPL given by load_template.py, they are correct:
![image](https://user-images.githubusercontent.com/102662583/189215072-79e97fe3-6283-4d9c-9c45-1551162475df.png)

Here is the joints orientation of SMPL given by load_AMASS.py, they don't make sense:
![image](https://user-images.githubusercontent.com/102662583/189215386-2e5db1fb-5ee7-4c52-9470-9c6b6c774c67.png)

Trying to propagate the global rotation to the joints becomes heavy so I suggest just rotating the SMPL Node instead to have the z axis up. 

**In this commit**, I modify the z_up flag to just set the Node.rotation to the proper rotation matrix, instead of rotating  mesh vertices.
I also added a z_up option to the PointClouds class to also rotate it in the Load_AMASS.py example.

This fixes AMASS joints orientation:
![image](https://user-images.githubusercontent.com/102662583/189216965-44c0ee12-b059-4c78-b030-c3f3fe2e1b10.png)

Note: The alternative would be to apply the global transformation every time the global_joint_ori are computed, which  would be done like this:
```
        rotated_joints_ori = np.zeros_like(self.joints_ori)
        for joint_idx in range(self.joints_ori.shape[1]):
            rotated_joints_ori[:,joint_idx,:,:] = np.matmul( self.rotation, self.joints_ori[:,joint_idx,:,:]) 
```




