### PR TITLE
Mac fixes for 1.6.0

### DIFF
--- a/aitviewer/headless.py
+++ b/aitviewer/headless.py
@@ -21,7 +21,6 @@ from PIL.Image import Image
 
 
 class HeadlessRenderer(Viewer):
-    gl_version = (4, 0)
     samples = 4
     window_type = 'headless'
 

--- a/aitviewer/scene/scene.py
+++ b/aitviewer/scene/scene.py
@@ -111,6 +111,8 @@ class Scene(Node):
                 # Otherwise append to transparent list
                 transparent.append(r)
 
+        fbo = kwargs['fbo']
+
         # Draw back to front by sorting transparent objects based on distance to camera.
         # As an approximation we only sort using the origin of the object
         # which may be incorrect for large objects or objects significantly
@@ -118,7 +120,10 @@ class Scene(Node):
         for r in sorted(transparent, key=lambda x: np.linalg.norm(x.position - self.camera.position), reverse=True):
             # Render to depth buffer only
             self.ctx.depth_func = '<'
+
+            fbo.color_mask = (False, False, False, False)
             self.safe_render_depth_prepass(r, **kwargs)
+            fbo.color_mask = (True, True, True, True)
 
             # Turn off backface culling if enabled for the scene
             # and requested by the current object

--- a/aitviewer/shaders/lines_instanced.vs.glsl
+++ b/aitviewer/shaders/lines_instanced.vs.glsl
@@ -1,4 +1,4 @@
-#version 430
+#version 400
 
 #include directional_lights.glsl
 

--- a/aitviewer/shaders/lines_instanced_positions.vs.glsl
+++ b/aitviewer/shaders/lines_instanced_positions.vs.glsl
@@ -1,4 +1,4 @@
-#version 430
+#version 400
 
 #include directional_lights.glsl
 

--- a/aitviewer/shaders/mesh_positions.vs.glsl
+++ b/aitviewer/shaders/mesh_positions.vs.glsl
@@ -12,6 +12,7 @@
     uniform mat4 model_matrix;
 
     out vec3 pos;
+    flat out int instance_id;
 
 
     void main() {
@@ -23,6 +24,7 @@
 #endif
         vec3 world_position = (transform * vec4(in_position, 1.0)).xyz;
         gl_Position = view_projection_matrix * vec4(world_position, 1.0);
+        instance_id = gl_InstanceID;
 
         pos = in_position;
     }

--- a/aitviewer/shaders/mesh_positions.vs.glsl
+++ b/aitviewer/shaders/mesh_positions.vs.glsl
@@ -1,9 +1,12 @@
-#version 430
+#version 400
 
 #define INSTANCED 0
 
 #if defined VERTEX_SHADER
     in vec3 in_position;
+#if INSTANCED
+    in mat4 instance_transform;
+#endif
 
     uniform mat4 view_projection_matrix;
     uniform mat4 model_matrix;
@@ -11,17 +14,10 @@
     out vec3 pos;
 
 
-#if INSTANCED
-    layout(std430, binding=1) buffer instance_data_buf
-    {
-        mat4 transforms[];
-    } instance_data;
-#endif
-
     void main() {
 
 #if INSTANCED
-        mat4 transform = model_matrix * instance_data.transforms[gl_InstanceID];
+        mat4 transform = model_matrix * instance_transform;
 #else
         mat4 transform = model_matrix;
 #endif

--- a/aitviewer/shaders/sphere_instanced.vs.glsl
+++ b/aitviewer/shaders/sphere_instanced.vs.glsl
@@ -1,4 +1,4 @@
-#version 430
+#version 400
 
 #include directional_lights.glsl
 

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -78,7 +78,7 @@ class Viewer(moderngl_window.WindowConfig):
     resource_dir = Path(__file__).parent / 'shaders'
     size_mult = 1.0
     samples = 4
-    gl_version = (4, 3)
+    gl_version = (4, 0)
     window_type = C.window_type
 
     def __init__(self, title="AITViewer", size: Tuple[int, int]=None, config: Union[DictConfig, dict]=None, samples: int=None, **kwargs):

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -465,7 +465,8 @@ class Viewer(moderngl_window.WindowConfig):
                           lights=self.scene.lights,
                           shadows_enabled=self.shadows_enabled,
                           show_camera_target=self.show_camera_target and not self._using_temp_camera,
-                          ambient_strength = self.scene.ambient_strength)
+                          ambient_strength = self.scene.ambient_strength,
+                          fbo=self.wnd.fbo)
 
     def render_prepare(self, transparent_background=True):
         """Prepare the framebuffer."""


### PR DESCRIPTION
Macs are stuck on openGL v 4.1 which doesn't support SSBO. We still provide mainline support for macOS, so this PR downgrades the ogl version to 4.0 to address this, as well as a minor transparency bug fix.