### PR TITLE
Update dependencies and required python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@23.3.0
+      - uses: psf/black@25.1.0
   isort:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
       - uses: isort/isort-action@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13]
-        python-version: ["3.7", "3.10"]
-        # exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
-        #   - python-version: "3.7"
-        #     os: macos-latest
-        # include:  # So run those legacy versions on Intel CPUs.
-        #   - python-version: "3.7"
-        #     os: macos-13
+        python-version: ["3.9", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/aitviewer/headless.py
+++ b/aitviewer/headless.py
@@ -92,7 +92,7 @@ class HeadlessRenderer(Viewer):
         self.run_animations = False
 
         # Render frame.
-        self.render(0, 0, export=True)
+        self.on_render(0, 0, export=True)
 
         # Restore run animation and update last frame rendered time.
         self.run_animations = run_animations

--- a/aitviewer/remote/message.py
+++ b/aitviewer/remote/message.py
@@ -13,6 +13,7 @@ class Message(enum.Enum):
     ARROWS = 5
     RIGID_BODIES = 6
     SMPL = 10
+    SKELETONS = 11
 
     # Messages used to modify existing nodes on the remote viewer.
     DELETE = 100

--- a/aitviewer/remote/renderables/skeletons.py
+++ b/aitviewer/remote/renderables/skeletons.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2023  ETH Zurich, Manuel Kaufmann, Velko Vechev, Dario Mylonopoulos
+from ..message import Message
+from ..node import RemoteNode
+
+
+class RemoteSkeletons(RemoteNode):
+    MESSAGE_TYPE = Message.SKELETONS
+
+    def __init__(self, viewer, joint_positions, joint_connections, **kwargs):
+        """
+        This initializer takes a RemoteViewer object and all other arguments are forwarded
+        to the Spheres constructor on the remote Viewer.
+        See the Spheres class for more information about parameters.
+
+        :param viewer: a RemoteViewer object that will be used to send this node.
+        :param joint_positions: A np array of shape (F, J, 3) containing J joint positions over F many time steps.
+        :param joint_connections: The definition of the skeleton as a numpy array of shape (N_LINES, 2) where each row
+          defines one connection between joints. The max entry in this array must be < J.
+        """
+        super().__init__(
+            viewer,
+            joint_positions=joint_positions,
+            joint_connections=joint_connections,
+            **kwargs,
+        )
+
+    def add_frames(self, joint_positions):
+        """
+        Add frames to the remote Spheres node by adding new sphere positions.
+
+        :param joint_positions: A np array of shape (N, J, 3) or (J, 3) containing J joint positions.
+        """
+        return super().add_frames(joint_positions=joint_positions)
+
+    def update_frames(self, joint_positions, frames):
+        """
+        Update frames of the remote Spheres node by updating the sphere positions.
+
+        :param joint_positions: A np array of shape (N, J, 3) containing J joint positions.
+        :param frames: a list of integer frame indices of size N or a single integer frame index.
+        """
+        return super().update_frames(joint_positions=joint_positions, frames=frames)

--- a/aitviewer/renderables/plane.py
+++ b/aitviewer/renderables/plane.py
@@ -192,7 +192,7 @@ class ChessboardPlane(Node):
 
         uvs = np.array([0, 0, 0, 1, 1, 0, 1, 1], dtype=np.float32)
 
-        return np.row_stack([p1, p0, p2, p3]), normals, uvs
+        return np.vstack([p1, p0, p2, p3]), normals, uvs
 
     # noinspection PyAttributeOutsideInit
     @Node.once

--- a/aitviewer/renderables/skeletons.py
+++ b/aitviewer/renderables/skeletons.py
@@ -136,3 +136,19 @@ class Skeletons(Node):
         self.material.color = color
         self.spheres.color = color
         self.lines.color = color
+
+    def update_frames(self, joint_positions, frames):
+        self.joint_positions[frames] = joint_positions
+        self.redraw()
+
+    def add_frames(self, joint_positions):
+        if len(joint_positions.shape) == 2:
+            joint_positions = joint_positions[np.newaxis]
+
+        self.joint_positions = np.append(self.joint_positions, joint_positions, axis=0)
+        self.spheres.add_frames(self.joint_positions)
+        self.lines.add_frames(self.joint_positions[:, self.skeleton].reshape(len(self), -1, 3))
+
+    def remove_frames(self, frames):
+        self.joint_positions = np.delete(self.joint_positions, frames, axis=0)
+        self.redraw()

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -18,7 +18,9 @@ from aitviewer.utils import interpolate_positions, local_to_global, resample_pos
 from aitviewer.utils import to_numpy as c2c
 from aitviewer.utils import to_torch
 from aitviewer.utils.decorators import hooked
-from aitviewer.utils.so3 import aa2euler_numpy
+from aitviewer.utils.so3 import (
+    aa2euler_numpy,
+)
 from aitviewer.utils.so3 import aa2rot_torch as aa2rot
 from aitviewer.utils.so3 import (
     euler2aa_numpy,

--- a/aitviewer/scene/camera.py
+++ b/aitviewer/scene/camera.py
@@ -286,7 +286,7 @@ class Camera(Node, CameraInterface):
         )
         self.add(self.frustum, show_in_hierarchy=False)
 
-        ori = np.eye(3, dtype=np.float)
+        ori = np.eye(3, dtype=np.float32)
         ori[:, 2] *= -1
         self.origin = RigidBodies(np.array([0.0, 0.0, 0.0])[np.newaxis], ori[np.newaxis])
         self.add(self.origin, show_in_hierarchy=False)

--- a/aitviewer/server.py
+++ b/aitviewer/server.py
@@ -13,6 +13,7 @@ from aitviewer.renderables.arrows import Arrows
 from aitviewer.renderables.lines import Lines
 from aitviewer.renderables.meshes import Meshes
 from aitviewer.renderables.rigid_bodies import RigidBodies
+from aitviewer.renderables.skeletons import Skeletons
 from aitviewer.renderables.smpl import SMPLSequence
 from aitviewer.renderables.spheres import Spheres
 from aitviewer.scene.node import Node
@@ -117,6 +118,9 @@ class ViewerServer:
 
         elif type == Message.RIGID_BODIES:
             add(client, remote_uid, args, kwargs, RigidBodies)
+
+        elif type == Message.SKELETONS:
+            add(client, remote_uid, args, kwargs, Skeletons)
 
         elif type == Message.SMPL:
             layer_arg_names = {"model_type", "gender", "num_betas"}

--- a/aitviewer/utils/imgui_integration.py
+++ b/aitviewer/utils/imgui_integration.py
@@ -22,6 +22,10 @@ class ImGuiRenderer(ModernglWindowRenderer):
 
         super().key_event(key, action, modifiers)
 
+    def mouse_scroll_event(self, x_offset, y_offset):
+        # HACK: pyimgui does not support horizontal scroll
+        self.io.mouse_wheel = y_offset
+
     def render(self, draw_data):
         # HACK: we set the modifiers here every frame because key_event is not called when
         # the window loses and regains focus (e.g. when changing focus with alt+tab)

--- a/aitviewer/utils/pyqt5_window.py
+++ b/aitviewer/utils/pyqt5_window.py
@@ -99,3 +99,18 @@ class PyQt5Window(Window):
 
     def _set_icon(self, icon_path: str) -> None:
         self._widget.setWindowIcon(QtGui.QIcon(str(icon_path)))
+
+    def resize(self, width: int, height: int) -> None:
+        """Replacement for Qt's ``resizeGL`` method.
+
+        Args:
+            width: New window width
+            height: New window height
+        """
+        self._width = width // self._widget.devicePixelRatio()
+        self._height = height // self._widget.devicePixelRatio()
+        self._buffer_width = width
+        self._buffer_height = height
+
+        # Make sure we notify the example about the resize
+        super(Window, self).resize(self._buffer_width, self._buffer_height)

--- a/aitviewer/utils/utils.py
+++ b/aitviewer/utils/utils.py
@@ -298,7 +298,7 @@ def compute_union_of_bounds(nodes):
     if len(nodes) == 0:
         return np.zeros((3, 2))
 
-    bounds = np.array([[np.inf, np.NINF], [np.inf, np.NINF], [np.inf, np.NINF]])
+    bounds = np.array([[np.inf, -np.inf], [np.inf, -np.inf], [np.inf, -np.inf]])
     for n in nodes:
         child = n.bounds
         bounds[:, 0] = np.minimum(bounds[:, 0], child[:, 0])
@@ -310,7 +310,7 @@ def compute_union_of_current_bounds(nodes):
     if len(nodes) == 0:
         return np.zeros((3, 2))
 
-    bounds = np.array([[np.inf, np.NINF], [np.inf, np.NINF], [np.inf, np.NINF]])
+    bounds = np.array([[np.inf, -np.inf], [np.inf, -np.inf], [np.inf, -np.inf]])
     for n in nodes:
         child = n.current_bounds
         bounds[:, 0] = np.minimum(bounds[:, 0], child[:, 0])

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -1498,13 +1498,16 @@ class Viewer(moderngl_window.WindowConfig):
                 self.scene.camera.position = position
                 self.scene.camera.target = target
 
-    def on_resize(self, width: int, height: int):
+    def resize(self, width: int, height: int):
         self.window_size = (width, height)
         self._resize_viewports()
         self.renderer.resize(width, height)
         self.imgui.resize(width, height)
 
-    def on_files_dropped_event(self, x: int, y: int, paths):
+    def on_resize(self, width: int, height: int):
+        return self.resize(width, height)
+
+    def files_dropped_event(self, x: int, y: int, paths):
         for path in paths:
             base, ext = os.path.splitext(path)
             if ext == ".obj" or ext == ".ply":
@@ -1514,7 +1517,10 @@ class Viewer(moderngl_window.WindowConfig):
                 obj_mesh = Meshes(obj.vertices, obj.faces, name=os.path.basename(base))
                 self.scene.add(obj_mesh)
 
-    def on_key_event(self, key, action, modifiers):
+    def on_files_dropped_event(self, x: int, y: int, paths):
+        return self.files_dropped_event(x, y, paths)
+
+    def key_event(self, key, action, modifiers):
         self.imgui.key_event(key, action, modifiers)
 
         # Handle keyboard shortcuts when the exit modal is open
@@ -1619,14 +1625,20 @@ class Viewer(moderngl_window.WindowConfig):
         if action == self.wnd.keys.ACTION_RELEASE:
             pass
 
-    def on_mouse_position_event(self, x, y, dx, dy):
+    def on_key_event(self, key, action, modifiers):
+        return self.key_event(key, action, modifiers)
+
+    def mouse_position_event(self, x, y, dx, dy):
         self._mouse_position = (x, y)
         self.imgui.mouse_position_event(x, y, dx, dy)
 
         if self.selected_mode == "inspect":
             self.mmi = self.mesh_mouse_intersection(x, y)
 
-    def on_mouse_press_event(self, x: int, y: int, button: int):
+    def on_mouse_position_event(self, x, y, dx, dy):
+        return self.mouse_position_event(x, y, dx, dy)
+
+    def mouse_press_event(self, x: int, y: int, button: int):
         self.imgui.mouse_press_event(x, y, button)
 
         if not self.imgui_user_interacting:
@@ -1654,7 +1666,10 @@ class Viewer(moderngl_window.WindowConfig):
             self._mouse_down_position = np.array([x, y])
             self._mouse_moved = False
 
-    def on_mouse_release_event(self, x: int, y: int, button: int):
+    def on_mouse_press_event(self, x: int, y: int, button: int):
+        return self.mouse_press_event(x, y, button)
+
+    def mouse_release_event(self, x: int, y: int, button: int):
         self.imgui.mouse_release_event(x, y, button)
 
         self._pan_camera = False
@@ -1669,7 +1684,10 @@ class Viewer(moderngl_window.WindowConfig):
                     if not self.lock_selection:
                         self.scene.select(None)
 
-    def on_mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
+    def on_mouse_release_event(self, x: int, y: int, button: int):
+        return self.mouse_release_event(x, y, button)
+
+    def mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
         self.imgui.mouse_drag_event(x, y, dx, dy)
 
         if not self.imgui_user_interacting:
@@ -1691,7 +1709,10 @@ class Viewer(moderngl_window.WindowConfig):
             ):
                 self._mouse_moved = True
 
-    def on_mouse_scroll_event(self, x_offset: float, y_offset: float):
+    def on_mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
+        return self.mouse_drag_event(x, y, dx, dy)
+
+    def mouse_scroll_event(self, x_offset: float, y_offset: float):
         self.imgui.mouse_scroll_event(x_offset, y_offset)
 
         if not self.imgui_user_interacting:
@@ -1700,8 +1721,14 @@ class Viewer(moderngl_window.WindowConfig):
                 self.reset_camera(v)
                 v.camera.dolly_zoom(np.sign(y_offset), self.wnd.modifiers.shift, self.wnd.modifiers.ctrl)
 
-    def on_unicode_char_entered(self, char):
+    def on_mouse_scroll_event(self, x_offset: float, y_offset: float):
+        return self.mouse_scroll_event(x_offset, y_offset)
+
+    def unicode_char_entered(self, char):
         self.imgui.unicode_char_entered(char)
+
+    def on_unicode_char_entered(self, char):
+        return self.unicode_char_entered(char)
 
     def save_current_frame_as_image(self, path, scale_factor=None, alpha=False):
         """Saves the current frame as an image to disk."""
@@ -1724,7 +1751,7 @@ class Viewer(moderngl_window.WindowConfig):
     def get_current_depth_image(self):
         return self.renderer.get_current_depth_image(self.scene.camera)
 
-    def on_close(self):
+    def close(self):
         """
         Clean up before destroying the window
         """
@@ -1740,6 +1767,9 @@ class Viewer(moderngl_window.WindowConfig):
         # have to recompile shaders with the current moderngl context.
         # See issue #12 https://github.com/eth-ait/aitviewer/issues/12
         clear_shader_cache()
+
+    def on_close(self):
+        return self.close()
 
     def take_screenshot(self, file_name=None, transparent_background=False):
         """Save the current frame to an image in the screenshots directory inside the export directory"""

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -526,7 +526,7 @@ class Viewer(moderngl_window.WindowConfig):
         if duration > 0 and log:
             print("Duration: {0:.2f}s @ {1:.2f} FPS".format(duration, self.window.frames / duration))
 
-    def render(self, time, frame_time, export=False, transparent_background=False):
+    def on_render(self, time, frame_time, export=False, transparent_background=False):
         """The main drawing function."""
 
         if self.run_animations:
@@ -1498,23 +1498,23 @@ class Viewer(moderngl_window.WindowConfig):
                 self.scene.camera.position = position
                 self.scene.camera.target = target
 
-    def resize(self, width: int, height: int):
+    def on_resize(self, width: int, height: int):
         self.window_size = (width, height)
         self._resize_viewports()
         self.renderer.resize(width, height)
         self.imgui.resize(width, height)
 
-    def files_dropped_event(self, x: int, y: int, paths):
+    def on_files_dropped_event(self, x: int, y: int, paths):
         for path in paths:
             base, ext = os.path.splitext(path)
             if ext == ".obj" or ext == ".ply":
                 import trimesh
 
-                obj = trimesh.load(path)
+                obj = trimesh.load(path, process=False)
                 obj_mesh = Meshes(obj.vertices, obj.faces, name=os.path.basename(base))
                 self.scene.add(obj_mesh)
 
-    def key_event(self, key, action, modifiers):
+    def on_key_event(self, key, action, modifiers):
         self.imgui.key_event(key, action, modifiers)
 
         # Handle keyboard shortcuts when the exit modal is open
@@ -1619,14 +1619,14 @@ class Viewer(moderngl_window.WindowConfig):
         if action == self.wnd.keys.ACTION_RELEASE:
             pass
 
-    def mouse_position_event(self, x, y, dx, dy):
+    def on_mouse_position_event(self, x, y, dx, dy):
         self._mouse_position = (x, y)
         self.imgui.mouse_position_event(x, y, dx, dy)
 
         if self.selected_mode == "inspect":
             self.mmi = self.mesh_mouse_intersection(x, y)
 
-    def mouse_press_event(self, x: int, y: int, button: int):
+    def on_mouse_press_event(self, x: int, y: int, button: int):
         self.imgui.mouse_press_event(x, y, button)
 
         if not self.imgui_user_interacting:
@@ -1654,7 +1654,7 @@ class Viewer(moderngl_window.WindowConfig):
             self._mouse_down_position = np.array([x, y])
             self._mouse_moved = False
 
-    def mouse_release_event(self, x: int, y: int, button: int):
+    def on_mouse_release_event(self, x: int, y: int, button: int):
         self.imgui.mouse_release_event(x, y, button)
 
         self._pan_camera = False
@@ -1669,7 +1669,7 @@ class Viewer(moderngl_window.WindowConfig):
                     if not self.lock_selection:
                         self.scene.select(None)
 
-    def mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
+    def on_mouse_drag_event(self, x: int, y: int, dx: int, dy: int):
         self.imgui.mouse_drag_event(x, y, dx, dy)
 
         if not self.imgui_user_interacting:
@@ -1691,7 +1691,7 @@ class Viewer(moderngl_window.WindowConfig):
             ):
                 self._mouse_moved = True
 
-    def mouse_scroll_event(self, x_offset: float, y_offset: float):
+    def on_mouse_scroll_event(self, x_offset: float, y_offset: float):
         self.imgui.mouse_scroll_event(x_offset, y_offset)
 
         if not self.imgui_user_interacting:
@@ -1700,7 +1700,7 @@ class Viewer(moderngl_window.WindowConfig):
                 self.reset_camera(v)
                 v.camera.dolly_zoom(np.sign(y_offset), self.wnd.modifiers.shift, self.wnd.modifiers.ctrl)
 
-    def unicode_char_entered(self, char):
+    def on_unicode_char_entered(self, char):
         self.imgui.unicode_char_entered(char)
 
     def save_current_frame_as_image(self, path, scale_factor=None, alpha=False):
@@ -1766,7 +1766,7 @@ class Viewer(moderngl_window.WindowConfig):
         self.run_animations = False
 
         # Render and save frame.
-        self.render(0, 0, export=True, transparent_background=transparent_background)
+        self.on_render(0, 0, export=True, transparent_background=transparent_background)
         self.save_current_frame_as_image(file_path, scale_factor, transparent_background)
 
         # Restore run animation and update last frame rendered time.
@@ -1927,7 +1927,7 @@ class Viewer(moderngl_window.WindowConfig):
             if rotate_camera:
                 self.scene.camera.rotate_azimuth(az_delta)
 
-            self.render(time, time + dt, export=True, transparent_background=transparent)
+            self.on_render(time, time + dt, export=True, transparent_background=transparent)
             img = self.get_current_frame_as_image(alpha=transparent)
 
             # Scale image by the scale factor.

--- a/examples/missing_frames.py
+++ b/examples/missing_frames.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     b = np.concatenate((betas[:25], betas[125:]))
 
     # Create a mask with N frames.
-    enabled_frames = np.ones(N, dtype=np.bool8)
+    enabled_frames = np.ones(N, dtype=bool)
     # Set to zero the values at the indices of the 100 missing frames. There are now only M ones in the mask.
     enabled_frames[25:125] = 0
 
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # during frames that are enabled (where the mask value is one).
     p2 = np.concatenate((poses[:175], poses[275:]))
     b2 = np.concatenate((betas[:175], betas[275:]))
-    enabled_frames2 = np.ones(N, dtype=np.bool8)
+    enabled_frames2 = np.ones(N, dtype=bool)
     enabled_frames2[175:275] = 0
     smpl_layer2 = SMPLLayer(model_type="smpl", gender="neutral", device=C.device)
     smpl_seq2 = SMPLSequence(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ profile = "black"
 
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ['py39']

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,14 @@ INSTALL_PYQT6 = os.getenv("AITVIEWER_INSTALL_PYQT6", 0)
 
 requirements = [
     "torch>=1.6.0",
-    "numpy>=1.18,<2",
+    "numpy>=1.18",
     "opencv-contrib-python-headless>=4.5.1.48",
     "smplx",
-    "moderngl-window>=2.4.3",
-    "moderngl>=5.8.2,<6",
+    "moderngl-window==3.1.1",
+    "moderngl==5.12.0",
     "imgui==2.0.0",
     "tqdm>=4.60.0",
-    "trimesh>=3.9.15,<4",
+    "trimesh>=4.4,<5",
     "scipy>=1.5.2",
     "omegaconf>=2.1.1",
     "roma>=1.2.3",
@@ -57,7 +57,7 @@ setup(
         "visualization",
     ],
     platforms=["any"],
-    python_requires=">=3.7,<3.11",
+    python_requires=">=3.9,<3.13",
     install_requires=requirements,
     project_urls={
         "Documentation": "https://eth-ait.github.io/aitviewer/",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -94,7 +94,7 @@ def test_empty(viewer: Viewer):
 
 
 def add_cube(viewer: Viewer, pos):
-    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False)
+    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False, maintain_order=True)
     cube_mesh = Meshes(cube.vertices, cube.faces, name="Cube", position=pos, flat_shading=True)
     viewer.scene.add(cube_mesh)
 
@@ -139,7 +139,7 @@ def test_opencv_camera(viewer: Viewer):
 
 @reference()
 def test_vertex_face_colors(viewer: Viewer):
-    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False)
+    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False, maintain_order=True)
 
     face_colors = np.array(
         [
@@ -271,7 +271,7 @@ def test_vertex_face_colors(viewer: Viewer):
 
 @reference()
 def test_instancing(viewer: Viewer):
-    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False)
+    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False, maintain_order=True)
     p = np.linspace(np.array([-8, 0, 0]), np.array([8, 0, 0]), num=10)
     r = aa2rot_numpy(np.linspace([0, 0, 0], np.array([0, 2 * np.pi, 0]), num=10))
     s = np.linspace(0.4, 0.8, num=10)

--- a/tests/test_renderables.py
+++ b/tests/test_renderables.py
@@ -48,7 +48,7 @@ def test_renderables(viewer: Viewer):
 
 @reference()
 def test_obj(viewer: Viewer):
-    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False)
+    cube = trimesh.load(os.path.join(RESOURCE_DIR, "cube.obj"), process=False, maintain_order=True)
     cube_mesh = Meshes(
         cube.vertices,
         cube.faces,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,7 +51,7 @@ def generate_images(viewer, count):
     viewer.run_animations = False
     # Render count frames, advancing the current frame at each iteration.
     for _ in range(count):
-        viewer.render(0, 0, export=True)
+        viewer.on_render(0, 0, export=True)
         yield viewer.get_current_frame_as_image()
         viewer.scene.next_frame()
 


### PR DESCRIPTION
Fixes #79 #71 and an issues with missing `np.NINF`, `np.float` and `np.bool8` in newer versions of numpy.

Also advances dependencies for moderngl, moderngl-window, numpy and trimesh and required python version to >=3.9,<3.13 

Some steps have been taken to ensure backwards compatibility, but differences in behavior with the newer trimesh and moderngl versions might be possible. However, we have to update these dependencies to support newer python and numpy versions.

It might make sense to backport some of the fixes and make a 1.13.1 patch release before releasing these changes as 1.14.0 to make a working version that support for python 3.7 and 3.8.