### PR TITLE
Add SMPL-X model support

### DIFF
--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -42,6 +42,10 @@ class SMPLSequence(Node):
         trans=None,
         poses_left_hand=None,
         poses_right_hand=None,
+        poses_jaw=None,
+        poses_leye=None,
+        poses_reye=None,
+        expression=None,
         device=None,
         dtype=None,
         include_root=True,
@@ -102,6 +106,9 @@ class SMPLSequence(Node):
         self.poses_body = to_torch(poses_body, dtype=dtype, device=device)
         self.poses_left_hand = to_torch(poses_left_hand, dtype=dtype, device=device)
         self.poses_right_hand = to_torch(poses_right_hand, dtype=dtype, device=device)
+        self.poses_jaw = to_torch(poses_jaw, dtype=dtype, device=device)
+        self.poses_leye = to_torch(poses_leye, dtype=dtype, device=device)
+        self.poses_reye = to_torch(poses_reye, dtype=dtype, device=device)
 
         poses_root = poses_root if poses_root is not None else torch.zeros([len(poses_body), 3])
         betas = betas if betas is not None else torch.zeros([1, self.smpl_layer.num_betas])
@@ -110,6 +117,8 @@ class SMPLSequence(Node):
         self.poses_root = to_torch(poses_root, dtype=dtype, device=device)
         self.betas = to_torch(betas, dtype=dtype, device=device)
         self.trans = to_torch(trans, dtype=dtype, device=device)
+        self.expression = to_torch(expression, dtype=dtype, device=device)
+
 
         if len(self.betas.shape) == 1:
             self.betas = self.betas.unsqueeze(0)
@@ -157,18 +166,18 @@ class SMPLSequence(Node):
 
         # First convert the relative joint angles to global joint angles in rotation matrix form.
         if self.smpl_layer.model_type != "flame":
-            if self.smpl_layer.model_type != "mano":
-                global_oris = local_to_global(
-                    torch.cat([self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand], dim=-1),
-                    self.skeleton[:, 0],
-                    output_format="rotmat",
-                )
-            else:
-                global_oris = local_to_global(
-                    torch.cat([self.poses_root, self.poses_body], dim=-1),
-                    self.skeleton[:, 0],
-                    output_format="rotmat",
-                )
+            # if self.smpl_layer.model_type != "mano":
+            #     global_oris = local_to_global(
+            #         torch.cat([self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand], dim=-1),
+            #         self.skeleton[:, 0],
+            #         output_format="rotmat",
+            #     )
+            # else:
+            global_oris = local_to_global(
+                torch.cat([self.poses_root, self.poses_body], dim=-1),
+                self.skeleton[:, 0],
+                output_format="rotmat",
+            )
             global_oris = c2c(global_oris.reshape((self.n_frames, -1, 3, 3)))
         else:
             global_oris = np.tile(np.eye(3), self.joints.shape[:-1])[np.newaxis]
@@ -384,6 +393,11 @@ class SMPLSequence(Node):
             )
             trans = self.trans[self.current_frame_id][None, :]
 
+            poses_jaw = None if self.poses_jaw is None else self.poses_jaw[self.current_frame_id][None, :]
+            poses_leye = None if self.poses_leye is None else self.poses_leye[self.current_frame_id][None, :]
+            poses_reye = None if self.poses_reye is None else self.poses_reye[self.current_frame_id][None, :]
+            expression = None if self.expression is None else self.expression[self.current_frame_id][None, :]
+
             if self.betas.shape[0] == self.n_frames:
                 betas = self.betas[self.current_frame_id][None, :]
             else:
@@ -404,6 +418,10 @@ class SMPLSequence(Node):
             poses_right_hand = self.poses_right_hand
             trans = self.trans
             betas = self.betas
+            poses_jaw = self.poses_jaw
+            poses_leye = self.poses_leye
+            poses_reye = self.poses_reye
+            expression = self.expression
 
         if self.smpl_layer.model_type == "mano":
             verts, joints = self.smpl_layer(
@@ -421,6 +439,10 @@ class SMPLSequence(Node):
                 poses_right_hand=poses_right_hand,
                 betas=betas,
                 trans=trans,
+                poses_jaw=poses_jaw,
+                poses_leye=poses_leye,
+                poses_reye=poses_reye,
+                expression=expression,
             )
 
         # Apply post_fk_func if specified.
@@ -432,6 +454,7 @@ class SMPLSequence(Node):
             if not self.smpl_layer.model_type == "mano"
             else self.smpl_layer.skeletons()["all"].T
         )
+
         faces = self.smpl_layer.bm.faces.astype(np.int64)
         joints = joints[:, : skeleton.shape[0]]
 

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -121,7 +121,6 @@ class SMPLSequence(Node):
         self.trans = to_torch(trans, dtype=dtype, device=device)
         self.expression = to_torch(expression, dtype=dtype, device=device)
 
-
         if len(self.betas.shape) == 1:
             self.betas = self.betas.unsqueeze(0)
 
@@ -168,13 +167,6 @@ class SMPLSequence(Node):
 
         # First convert the relative joint angles to global joint angles in rotation matrix form.
         if self.smpl_layer.model_type != "flame":
-            # if self.smpl_layer.model_type != "mano":
-            #     global_oris = local_to_global(
-            #         torch.cat([self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand], dim=-1),
-            #         self.skeleton[:, 0],
-            #         output_format="rotmat",
-            #     )
-            # else:
             global_oris = local_to_global(
                 torch.cat([self.poses_root, self.poses_body], dim=-1),
                 self.skeleton[:, 0],

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2023  ETH Zurich, Manuel Kaufmann, Velko Vechev, Dario Mylonopoulos
+from aitviewer.models.smpl import SMPLLayer
 from aitviewer.renderables.smpl import SMPLSequence
 from aitviewer.viewer import Viewer
 
 if __name__ == "__main__":
     v = Viewer()
-    v.scene.add(SMPLSequence.t_pose())
+    smpl_layer = SMPLLayer(model_type="smplx", gender="neutral")
+    v.scene.add(SMPLSequence.t_pose(smpl_layer))
     v.run()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "Pillow",
     "websockets",
     "usd-core>=23.5",
-    "black>=26.3.0"
+    "black>=26.3.0",
 ]
 
 # Choose PyQt version depending on environment variable.

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,7 @@ requirements = [
     "websockets",
     "usd-core>=23.5",
     "black>=26.3.0",
-<<<<<<< feature/smplx-support
-=======
     "isort",
->>>>>>> main
 ]
 
 # Choose PyQt version depending on environment variable.


### PR DESCRIPTION
I made few changes to support the SMPL-X model. 
The additional parameters required by the model were supported in the `SMPLLayer `class, but not in the SMPLSequence. 
I fixed the `SMPLSequence `by making it support these additional parameters, specifically:
- `poses_jaw`, expected to be a 1 x 3 tensor
- `poses_leye`, expected to be a 1 x 3 tensor
- `poses_reye`, expected to be a 1 x 3 tensor
and, additionally to these, also the expression coefficients to model face expression.

I also commented the lines
```
# if self.smpl_layer.model_type != "mano":
#     global_oris = local_to_global(
#         torch.cat([self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand], dim=-1),
#         self.skeleton[:, 0],
#         output_format="rotmat",
#     )
# else:
```
Since this code only supports the skeleton for the SMPL body model. The lack of support for the parameters of SMPL-H (And consequently of SMPL-X) can be seen in [this repo](https://github.com/paulbuttler/dslab-project4) I had to work with, where the authors suggest to comment the same lines.

Remaining changes are just done resembling what was being done with the remaining parameters 
