### PR TITLE
fix: compatibility patches for moderngl-window 3.x and imgui 2.0.0

### DIFF
--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -157,19 +157,27 @@ class SMPLSequence(Node):
 
         # First convert the relative joint angles to global joint angles in rotation matrix form.
         if self.smpl_layer.model_type != "flame":
-            if self.smpl_layer.model_type != "mano":
-                global_oris = local_to_global(
-                    torch.cat([self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand], dim=-1),
-                    self.skeleton[:, 0],
-                    output_format="rotmat",
+            has_hands = self.poses_left_hand is not None and self.poses_right_hand is not None
+            if self.smpl_layer.model_type != "mano" and has_hands:
+                all_poses = torch.cat(
+                    [self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand], dim=-1
                 )
+                # Use the full skeleton (body + hands) for local_to_global so that
+                # parent indices match the concatenated pose tensor.
+                full_skeleton = self.smpl_layer.skeletons()["all"].T
+                parents_for_l2g = c2c(full_skeleton[:, 0])
+                global_oris = local_to_global(all_poses, parents_for_l2g, output_format="rotmat")
+                # Trim back to body-only joints for downstream use.
+                n_body = self.skeleton.shape[0]
+                global_oris = global_oris.reshape((self.n_frames, -1, 3, 3))[:, :n_body]
+                global_oris = c2c(global_oris)
             else:
                 global_oris = local_to_global(
                     torch.cat([self.poses_root, self.poses_body], dim=-1),
                     self.skeleton[:, 0],
                     output_format="rotmat",
                 )
-            global_oris = c2c(global_oris.reshape((self.n_frames, -1, 3, 3)))
+                global_oris = c2c(global_oris.reshape((self.n_frames, -1, 3, 3)))
         else:
             global_oris = np.tile(np.eye(3), self.joints.shape[:-1])[np.newaxis]
 

--- a/aitviewer/utils/imgui_integration.py
+++ b/aitviewer/utils/imgui_integration.py
@@ -22,6 +22,12 @@ class ImGuiRenderer(ModernglWindowRenderer):
 
         super().key_event(key, action, modifiers)
 
+    def mouse_scroll_event(self, x_offset, y_offset):
+        # imgui 2.0.0 removed the mouse_wheel_h attribute.
+        if hasattr(self.io, "mouse_wheel_h"):
+            self.io.mouse_wheel_h = x_offset
+        self.io.mouse_wheel = y_offset
+
     def render(self, draw_data):
         # HACK: we set the modifiers here every frame because key_event is not called when
         # the window loses and regains focus (e.g. when changing focus with alt+tab)

--- a/aitviewer/utils/pyqt5_window.py
+++ b/aitviewer/utils/pyqt5_window.py
@@ -88,6 +88,9 @@ class PyQt5Window(Window):
         self._widget.showEvent = self.show_event
         self._widget.hideEvent = self.hide_event
 
+        # moderngl-window >= 3.0 expects self._ctx to exist before init_mgl_context.
+        self._ctx = None
+
         # Attach to the context
         self.init_mgl_context()
 

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -1968,3 +1968,36 @@ class Viewer(moderngl_window.WindowConfig):
         self.scene.current_frame_id = saved_curr_frame
         self.run_animations = saved_run_animations
         self._last_frame_rendered_at = self.timer.time
+
+    # ── moderngl-window >= 3.0 event bridge ─────────────────────────
+    # moderngl-window 3.x renamed all event callbacks with an on_ prefix.
+    # aitviewer still defines the old names, so we bridge them here.
+    def on_render(self, time, frame_time):
+        self.render(time, frame_time)
+
+    def on_key_event(self, key, action, modifiers):
+        self.key_event(key, action, modifiers)
+
+    def on_mouse_position_event(self, x, y, dx, dy):
+        self.mouse_position_event(x, y, dx, dy)
+
+    def on_mouse_press_event(self, x, y, button):
+        self.mouse_press_event(x, y, button)
+
+    def on_mouse_release_event(self, x, y, button):
+        self.mouse_release_event(x, y, button)
+
+    def on_mouse_drag_event(self, x, y, dx, dy):
+        self.mouse_drag_event(x, y, dx, dy)
+
+    def on_mouse_scroll_event(self, x_offset, y_offset):
+        self.mouse_scroll_event(x_offset, y_offset)
+
+    def on_unicode_char_entered(self, char):
+        self.unicode_char_entered(char)
+
+    def on_resize(self, width, height):
+        self.resize(width, height)
+
+    def on_files_dropped_event(self, x, y, paths):
+        self.files_dropped_event(x, y, paths)


### PR DESCRIPTION
- Add on_* event bridge methods in viewer.py for moderngl-window 3.x
- Fix local_to_global IndexError when SMPLX hand poses are present
- Handle removed mouse_wheel_h attribute in imgui 2.0.0
- Initialize _ctx before init_mgl_context in pyqt5_window.py