### PR TITLE
Add point cloud splatting shader.

### DIFF
--- a/aitviewer/renderables/point_clouds.py
+++ b/aitviewer/renderables/point_clouds.py
@@ -9,7 +9,6 @@ from aitviewer.shaders import (
     get_fragmap_program,
     get_outline_program,
     get_point_cloud_program,
-    get_simple_unlit_program,
 )
 from aitviewer.utils.decorators import hooked
 
@@ -23,10 +22,9 @@ class PointClouds(Node):
         self,
         points,
         colors=None,
-        point_size=5.0,
-        adaptive_point_size=False,
-        min_point_size=1.0,
-        max_point_size=20.0,
+        point_size=50.0,
+        min_point_size=5.0,
+        max_point_size=100.0,
         color=(0.0, 0.0, 1.0, 1.0),
         z_up=False,
         icon="\u008c",
@@ -35,16 +33,17 @@ class PointClouds(Node):
     ):
         """
         A sequence of point clouds. Each point cloud can have a varying number of points.
+        Points are rendered with adaptive sizing using a dedicated shader.
         :param points: Sequence of points (F, P, 3)
         :param colors: Sequence of Colors (F, C, 4) or None. If None, all points are colored according to `color`.
         :param point_size: Initial point size.
-        :param adaptive_point_size: If True, points are rendered with adaptive sizing using a dedicated shader.
         :param min_point_size: Minimum point size (in pixels) for adaptive rendering.
         :param max_point_size: Maximum point size (in pixels) for adaptive rendering.
         :param color: Default color applied to all points of all frames if `colors` is not provided.
         :param z_up: If true the point cloud rotation matrix is initialized to convert from z-up to y-up data.
         """
         assert isinstance(points, list) or isinstance(points, np.ndarray)
+        assert len(points.shape) == 3
         if colors is not None:
             assert len(colors) == len(points)
 
@@ -58,17 +57,14 @@ class PointClouds(Node):
 
         self.colors = colors
         self.point_size = point_size
-        self.adaptive_point_size = adaptive_point_size
         self.min_point_size = min_point_size
         self.max_point_size = max_point_size
-        if self.adaptive_point_size:
-            if not (self.min_point_size > 0.0 and self.max_point_size > self.min_point_size):
-                raise ValueError("Adaptive point sizes require 0 < min_point_size < max_point_size.")
+        if not (self.min_point_size > 0.0 and self.max_point_size > self.min_point_size):
+            raise ValueError("Adaptive point sizes require 0 < min_point_size < max_point_size.")
 
         self.max_n_points = max([p.shape[0] for p in self.points])
 
         self.vao = VAO("points", mode=moderngl.POINTS)
-        self._ctx = None
 
         if z_up and not C.z_up:
             self.rotation = np.matmul(np.array([[1, 0, 0], [0, 0, 1], [0, -1, 0]]), self.rotation)
@@ -180,14 +176,15 @@ class PointClouds(Node):
     # noinspection PyAttributeOutsideInit
     @Node.once
     def make_renderable(self, ctx):
-        self._ctx = ctx
+        self.ctx = ctx
+
+        # With moderngl.PROGRAM_POINT_SIZE active, the ctx.point_size attribute
+        # is overlooked and instead gl_PointSize must be set in the shader.
+        # We still set the ctx.point_size attribute here in case moderngl.PROGRAM_POINT_SIZE
+        # fails on a platform.
         ctx.point_size = self.point_size
 
-        if self.adaptive_point_size:
-            ctx.enable(moderngl.PROGRAM_POINT_SIZE)
-            self.prog = get_point_cloud_program()
-        else:
-            self.prog = get_simple_unlit_program()
+        self.prog = get_point_cloud_program()
         self.outline_program = get_outline_program("mesh_positions.vs.glsl")
         self.fragmap_program = get_fragmap_program("mesh_positions.vs.glsl")
 
@@ -203,18 +200,20 @@ class PointClouds(Node):
 
     def render(self, camera, **kwargs):
         self.set_camera_matrices(self.prog, camera, **kwargs)
-        if self.adaptive_point_size:
-            model_view_matrix = camera.get_view_matrix() @ self.model_matrix
-            projection_matrix = camera.get_projection_matrix()
-            projection_scale = float(projection_matrix[1, 1])
-            is_ortho = int(getattr(camera, "is_ortho", False))
+        self.ctx.enable(moderngl.PROGRAM_POINT_SIZE)
 
-            self.prog["model_view_matrix"].write(model_view_matrix.T.astype("f4").tobytes())
-            self.prog["base_point_size"].value = self.point_size
-            self.prog["min_point_size"].value = self.min_point_size
-            self.prog["max_point_size"].value = self.max_point_size
-            self.prog["projection_scale"].value = projection_scale
-            self.prog["orthographic"].value = is_ortho
+        model_view_matrix = camera.get_view_matrix() @ self.model_matrix
+        projection_matrix = camera.get_projection_matrix()
+        projection_scale = float(projection_matrix[1, 1])
+        is_ortho = int(getattr(camera, "is_ortho", False))
+
+        self.prog["model_view_matrix"].write(model_view_matrix.T.astype("f4").tobytes())
+        self.prog["base_point_size"].value = self.point_size
+        self.prog["min_point_size"].value = self.min_point_size
+        self.prog["max_point_size"].value = self.max_point_size
+        self.prog["projection_scale"].value = projection_scale
+        self.prog["orthographic"].value = is_ortho
+
         # Draw only as many points as we have set in the buffer.
         self.vao.render(self.prog, vertices=len(self.current_points))
 
@@ -233,31 +232,30 @@ class PointClouds(Node):
         )
         if changed:
             self.point_size = point_size
-            if self._ctx is not None and self.is_renderable and not self.adaptive_point_size:
-                self._ctx.point_size = self.point_size
+            if self.ctx is not None and self.is_renderable:
+                self.ctx.point_size = self.point_size
 
-        if self.adaptive_point_size:
-            changed_min, min_point_size = imgui.drag_float(
-                "Min Point Size##{}".format(self.unique_name),
-                self.min_point_size,
-                0.1,
-                min_value=0.1,
-                max_value=max(self.min_point_size + 0.1, self.max_point_size),
-                format="%.2f",
-            )
-            if changed_min:
-                self.min_point_size = max(0.1, min(min_point_size, self.max_point_size - 0.1))
+        changed_min, min_point_size = imgui.drag_float(
+            "Min Point Size##{}".format(self.unique_name),
+            self.min_point_size,
+            0.1,
+            min_value=0.1,
+            max_value=max(self.min_point_size + 0.1, self.max_point_size),
+            format="%.2f",
+        )
+        if changed_min:
+            self.min_point_size = max(0.1, min(min_point_size, self.max_point_size - 0.1))
 
-            changed_max, max_point_size = imgui.drag_float(
-                "Max Point Size##{}".format(self.unique_name),
-                self.max_point_size,
-                0.1,
-                min_value=max(self.min_point_size + 0.1, 0.2),
-                max_value=1000.0,
-                format="%.2f",
-            )
-            if changed_max:
-                self.max_point_size = max(self.min_point_size + 0.1, max_point_size)
+        changed_max, max_point_size = imgui.drag_float(
+            "Max Point Size##{}".format(self.unique_name),
+            self.max_point_size,
+            0.1,
+            min_value=max(self.min_point_size + 0.1, 0.2),
+            max_value=1000.0,
+            format="%.2f",
+        )
+        if changed_max:
+            self.max_point_size = max(self.min_point_size + 0.1, max_point_size)
 
         super().gui(imgui)
 
@@ -266,4 +264,4 @@ class PointClouds(Node):
         if self.is_renderable:
             self.vao.release()
             self.positions_vao.release(buffer=False)
-        self._ctx = None
+        self.ctx = None

--- a/aitviewer/renderables/point_clouds.py
+++ b/aitviewer/renderables/point_clouds.py
@@ -8,6 +8,7 @@ from aitviewer.scene.node import Node
 from aitviewer.shaders import (
     get_fragmap_program,
     get_outline_program,
+    get_point_cloud_program,
     get_simple_unlit_program,
 )
 from aitviewer.utils.decorators import hooked
@@ -23,6 +24,9 @@ class PointClouds(Node):
         points,
         colors=None,
         point_size=5.0,
+        adaptive_point_size=False,
+        min_point_size=1.0,
+        max_point_size=20.0,
         color=(0.0, 0.0, 1.0, 1.0),
         z_up=False,
         icon="\u008c",
@@ -34,6 +38,9 @@ class PointClouds(Node):
         :param points: Sequence of points (F, P, 3)
         :param colors: Sequence of Colors (F, C, 4) or None. If None, all points are colored according to `color`.
         :param point_size: Initial point size.
+        :param adaptive_point_size: If True, points are rendered with adaptive sizing using a dedicated shader.
+        :param min_point_size: Minimum point size (in pixels) for adaptive rendering.
+        :param max_point_size: Maximum point size (in pixels) for adaptive rendering.
         :param color: Default color applied to all points of all frames if `colors` is not provided.
         :param z_up: If true the point cloud rotation matrix is initialized to convert from z-up to y-up data.
         """
@@ -51,9 +58,17 @@ class PointClouds(Node):
 
         self.colors = colors
         self.point_size = point_size
+        self.adaptive_point_size = adaptive_point_size
+        self.min_point_size = min_point_size
+        self.max_point_size = max_point_size
+        if self.adaptive_point_size:
+            if not (self.min_point_size > 0.0 and self.max_point_size > self.min_point_size):
+                raise ValueError("Adaptive point sizes require 0 < min_point_size < max_point_size.")
+
         self.max_n_points = max([p.shape[0] for p in self.points])
 
         self.vao = VAO("points", mode=moderngl.POINTS)
+        self._ctx = None
 
         if z_up and not C.z_up:
             self.rotation = np.matmul(np.array([[1, 0, 0], [0, 0, 1], [0, -1, 0]]), self.rotation)
@@ -165,9 +180,14 @@ class PointClouds(Node):
     # noinspection PyAttributeOutsideInit
     @Node.once
     def make_renderable(self, ctx):
+        self._ctx = ctx
         ctx.point_size = self.point_size
 
-        self.prog = get_simple_unlit_program()
+        if self.adaptive_point_size:
+            ctx.enable(moderngl.PROGRAM_POINT_SIZE)
+            self.prog = get_point_cloud_program()
+        else:
+            self.prog = get_simple_unlit_program()
         self.outline_program = get_outline_program("mesh_positions.vs.glsl")
         self.fragmap_program = get_fragmap_program("mesh_positions.vs.glsl")
 
@@ -183,6 +203,18 @@ class PointClouds(Node):
 
     def render(self, camera, **kwargs):
         self.set_camera_matrices(self.prog, camera, **kwargs)
+        if self.adaptive_point_size:
+            model_view_matrix = camera.get_view_matrix() @ self.model_matrix
+            projection_matrix = camera.get_projection_matrix()
+            projection_scale = float(projection_matrix[1, 1])
+            is_ortho = int(getattr(camera, "is_ortho", False))
+
+            self.prog["model_view_matrix"].write(model_view_matrix.T.astype("f4").tobytes())
+            self.prog["base_point_size"].value = self.point_size
+            self.prog["min_point_size"].value = self.min_point_size
+            self.prog["max_point_size"].value = self.max_point_size
+            self.prog["projection_scale"].value = projection_scale
+            self.prog["orthographic"].value = is_ortho
         # Draw only as many points as we have set in the buffer.
         self.vao.render(self.prog, vertices=len(self.current_points))
 
@@ -190,8 +222,48 @@ class PointClouds(Node):
         if self.is_renderable:
             self.positions_vao.render(prog, vertices=len(self.current_points))
 
+    def gui(self, imgui):
+        changed, point_size = imgui.drag_float(
+            "Point Size##{}".format(self.unique_name),
+            self.point_size,
+            0.1,
+            min_value=0.1,
+            max_value=500.0,
+            format="%.2f",
+        )
+        if changed:
+            self.point_size = point_size
+            if self._ctx is not None and self.is_renderable and not self.adaptive_point_size:
+                self._ctx.point_size = self.point_size
+
+        if self.adaptive_point_size:
+            changed_min, min_point_size = imgui.drag_float(
+                "Min Point Size##{}".format(self.unique_name),
+                self.min_point_size,
+                0.1,
+                min_value=0.1,
+                max_value=max(self.min_point_size + 0.1, self.max_point_size),
+                format="%.2f",
+            )
+            if changed_min:
+                self.min_point_size = max(0.1, min(min_point_size, self.max_point_size - 0.1))
+
+            changed_max, max_point_size = imgui.drag_float(
+                "Max Point Size##{}".format(self.unique_name),
+                self.max_point_size,
+                0.1,
+                min_value=max(self.min_point_size + 0.1, 0.2),
+                max_value=1000.0,
+                format="%.2f",
+            )
+            if changed_max:
+                self.max_point_size = max(self.min_point_size + 0.1, max_point_size)
+
+        super().gui(imgui)
+
     @hooked
     def release(self):
         if self.is_renderable:
             self.vao.release()
             self.positions_vao.release(buffer=False)
+        self._ctx = None

--- a/aitviewer/renderer.py
+++ b/aitviewer/renderer.py
@@ -176,6 +176,7 @@ class Renderer:
 
         # Configure OpenGL context.
         self.ctx.enable_only(moderngl.DEPTH_TEST | moderngl.BLEND | moderngl.CULL_FACE)
+        self.ctx.enable(moderngl.PROGRAM_POINT_SIZE)
         self.ctx.cull_face = "back"
         self.ctx.blend_func = (
             moderngl.SRC_ALPHA,

--- a/aitviewer/renderer.py
+++ b/aitviewer/renderer.py
@@ -176,7 +176,6 @@ class Renderer:
 
         # Configure OpenGL context.
         self.ctx.enable_only(moderngl.DEPTH_TEST | moderngl.BLEND | moderngl.CULL_FACE)
-        self.ctx.enable(moderngl.PROGRAM_POINT_SIZE)
         self.ctx.cull_face = "back"
         self.ctx.blend_func = (
             moderngl.SRC_ALPHA,

--- a/aitviewer/scene/node.py
+++ b/aitviewer/scene/node.py
@@ -110,6 +110,10 @@ class Node(object):
         self.fragmap = False
         self.outline = False
 
+        # Keep a reference to the OpenGL context passed into `make_renderable`.
+        # Each subclass decides if she needs that.
+        self.ctx = None
+
         # Programs for render passes. Subclasses are responsible for setting these.
         self.depth_only_program = None  # Required for depth_prepass and cast_shadow passes
         self.fragmap_program = None  # Required for fragmap pass

--- a/aitviewer/shaders.py
+++ b/aitviewer/shaders.py
@@ -103,6 +103,11 @@ def get_simple_unlit_program():
 
 
 @functools.lru_cache()
+def get_point_cloud_program():
+    return load_program("point_clouds.glsl")
+
+
+@functools.lru_cache()
 def get_cylinder_program():
     return load_program("cylinder.glsl")
 
@@ -160,6 +165,7 @@ def clear_shader_cache():
         get_fragmap_program,
         get_depth_only_program,
         get_simple_unlit_program,
+        get_point_cloud_program,
         get_cylinder_program,
         get_screen_texture_program,
         get_chessboard_program,

--- a/aitviewer/shaders/point_clouds.glsl
+++ b/aitviewer/shaders/point_clouds.glsl
@@ -1,0 +1,55 @@
+#version 400
+
+// Copyright (C) 2023  ETH Zurich, Manuel Kaufmann, Velko Vechev, Dario Mylonopoulos
+
+#if defined VERTEX_SHADER
+
+    in vec3 in_position;
+    in vec4 in_color;
+
+    uniform mat4 model_matrix;
+    uniform mat4 model_view_matrix;
+    uniform mat4 view_projection_matrix;
+
+    uniform float base_point_size;
+    uniform float min_point_size;
+    uniform float max_point_size;
+    uniform float projection_scale;
+    uniform int orthographic;
+
+    out vec4 v_color;
+
+    void main() {
+        vec4 world_position = model_matrix * vec4(in_position, 1.0);
+        vec4 view_position = model_view_matrix * vec4(in_position, 1.0);
+
+        float depth = max(0.0001, abs(view_position.z));
+        float adaptive_size = base_point_size;
+        if (orthographic == 0) {
+            adaptive_size = base_point_size * projection_scale / depth;
+        }
+        adaptive_size = clamp(adaptive_size, min_point_size, max_point_size);
+
+        gl_Position = view_projection_matrix * world_position;
+        gl_PointSize = adaptive_size;
+        v_color = in_color;
+    }
+
+#elif defined FRAGMENT_SHADER
+
+    in vec4 v_color;
+
+    out vec4 f_color;
+
+    void main() {
+        vec2 coords = gl_PointCoord * 2.0 - 1.0;
+        float radius_sq = dot(coords, coords);
+
+        if (radius_sq > 1.0) {
+            discard;
+        }
+
+        f_color = vec4(v_color.rgb, v_color.a);
+    }
+
+#endif

--- a/examples/load_point_clouds.py
+++ b/examples/load_point_clouds.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2023  ETH Zurich, Manuel Kaufmann, Velko Vechev, Dario Mylonopoulos
+import trimesh
+
+from aitviewer.renderables.point_clouds import PointClouds
+from aitviewer.viewer import Viewer
+
+if __name__ == "__main__":
+    v = Viewer()
+    sphere = trimesh.load("resources/planet/planet.obj")
+    point_cloud = PointClouds(sphere.vertices[None])
+    v.scene.add(point_cloud)
+    v.run()


### PR DESCRIPTION
Add a dedicated splatting shader for point clouds so each point can be rendered as a screen-space disk with a configurable size, rather than the default fixed-size GL point.

### Changes
- New shader `aitviewer/shaders/point_clouds.glsl` that draws per-point splats and uses `gl_PointSize`.
- Register `get_point_cloud_program()` in `aitviewer/shaders.py`.
- Enable `moderngl.PROGRAM_POINT_SIZE` in `aitviewer/renderer.py` so the vertex shader can control point size.
- Wire the new shader into `aitviewer/renderables/point_clouds.py`.